### PR TITLE
Start interval signal

### DIFF
--- a/buffer_block.py
+++ b/buffer_block.py
@@ -113,7 +113,6 @@ class Buffer(Persistence, GroupBy, Block):
                 reset=False,
             )
             self._active_job = True
-        print(self._active_job)
 
 
     def process_group(self, signals, key):

--- a/tests/test_buffer_block.py
+++ b/tests/test_buffer_block.py
@@ -142,11 +142,13 @@ class TestBuffer(NIOBlockTestCase):
             "signal_start": True
         })
         block.start()
+        event.wait(.1)
+        block.process_signals([Signal()])
+        event.wait(.1)
+        block.process_signals([Signal()])
+        # 200 miliseconds have now passed but the block should have only been active for 100
         self.assert_num_signals_notified(0, block)
         event.wait(.1)
-        block.process_signals([Signal()])
-        event.wait(.1) # 200 miliseconds have now passed but the block should have only been active for 100
-        block.process_signals([Signal()])
-        event.wait(.1)
-        self.assert_num_signals_notified(2, block) # This would be 1 if signal_start is False
+        self.assert_num_signals_notified(2, block)
+        # This would be 1 if signal_start is False
         block.stop()


### PR DESCRIPTION
The buffer block currently begins its interval on service start and continuously resets after this interval. This has been problematic for one case that I have used it. This PR will add an option to start the interval on a signal rather than on service start and prevent it from resetting. An additional test has been created for this new property. This may however be a solution to a very specific problem.